### PR TITLE
Remove trait glob import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ use num::traits::cast;
 use std::f64;
 use std::ops::{Add,Mul,Div,Sub,Neg};
 use std::cmp::Ordering;
-pub use Angle::*;
 
 
 


### PR DESCRIPTION
The import should have had no effect and will become an error once rust-lang/rust#32134 lands.
